### PR TITLE
WIP: Qrack Arithmetic ("ALU")

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Pure Python bindings for the pure C++11/OpenCL Qrack quantum computer simulator 
 
 Import and instantiate [`QrackSimulator`](https://github.com/vm6502q/pyqrack/blob/main/pyqrack/qrack_simulator.py) instances. This simulator can perform arbitrary single qubit and controlled-single-qubit gates, as well as other specific gates like `SWAP`.
 
-Any and all 2x2 bit operator matrices are composed of 8 `double` floating point numbers, to represent 4 complex numbers. `double` arrays or lists, in this case, are **real** component followed immediately by **imaginary** component, then [**row-major order**](https://en.wikipedia.org/wiki/Row-_and_column-major_order).
+Any 2x2 bit operator matrices is represented by a list of 4 `complex` floating point numbers, in [**row-major order**](https://en.wikipedia.org/wiki/Row-_and_column-major_order).
 
 Single and array "`b`" parameters represent [**Pauli operator bases**](https://en.wikipedia.org/wiki/Pauli_matrices). They are specifiied according to the enumeration of the [`Pauli`](https://github.com/vm6502q/pyqrack/blob/main/pyqrack/pauli.py) class.
 

--- a/pyqrack/qrack_simulator.py
+++ b/pyqrack/qrack_simulator.py
@@ -34,10 +34,12 @@ class QrackSimulator:
     def _to_ubyte(self, nv, v):
         b = (c_ubyte * (1 << nv))()
         c = math.floor((nv - 1) / 8) + 1
+        n = 0
         for u in v:
             for i in range(c):
-                b[i] = u & 0xFF
+                b[n] = u & 0xFF
                 u >>= 8
+                n += 1
 
         return byref(b)
 

--- a/pyqrack/qrack_simulator.py
+++ b/pyqrack/qrack_simulator.py
@@ -36,7 +36,7 @@ class QrackSimulator:
 
     def _to_ubyte(self, nv, v):
         b = []
-        c = math.floor(nv - 1) / 8) + 1
+        c = math.floor((nv - 1) / 8) + 1
         if c > 0:
             for u in v:
                 for i in range(c):
@@ -331,13 +331,6 @@ class QrackSimulator:
 
     def sbc(self, s, qi, qv, t):
         Qrack.qrack_lib.ADC(self.sid, s, len(qi), self._uint_byref(qi), len(qv), self._uint_byref(qv), self._to_ubyte(t))
-
-MICROSOFT_QUANTUM_DECL void LDA(_In_ unsigned sid, _In_ unsigned ni, _In_reads_(ni) unsigned* qi, _In_ unsigned nv,
-    _In_reads_(nv) unsigned* qv, unsigned char* t);
-MICROSOFT_QUANTUM_DECL void ADC(_In_ unsigned sid, unsigned s, _In_ unsigned ni, _In_reads_(ni) unsigned* qi,
-    _In_ unsigned nv, _In_reads_(nv) unsigned* qv, unsigned char* t);
-MICROSOFT_QUANTUM_DECL void SBC(_In_ unsigned sid, unsigned s, _In_ unsigned ni, _In_reads_(ni) unsigned* qi,
-    _In_ unsigned nv, _In_reads_(nv) unsigned* qv, unsigned char* t);
 
     # miscellaneous
 

--- a/pyqrack/qrack_simulator.py
+++ b/pyqrack/qrack_simulator.py
@@ -3,7 +3,7 @@
 # Use of this source code is governed by an MIT-style license that can be
 # found in the LICENSE file or at https://opensource.org/licenses/MIT.
 
-import math
+import math, cmath
 from ctypes import *
 from .qrack_system import Qrack
 
@@ -30,6 +30,10 @@ class QrackSimulator:
 
     def _double_byref(self, a):
         return (c_double * len(a))(*a)
+
+    def _complex_byref(self, a):
+        t = [(c.real, c.imag) for c in a]
+        return self._double_byref([item for sublist in t for item in sublist])
 
     def _to_ubyte(self, nv, v):
         b = (c_ubyte * (1 << nv))()
@@ -104,7 +108,7 @@ class QrackSimulator:
         Qrack.qrack_lib.U(self.sid, q, c_double(th), c_double(ph), c_double(la))
 
     def mtrx(self, m, q):
-        Qrack.qrack_lib.Mtrx(self.sid, self._double_byref(m), q)
+        Qrack.qrack_lib.Mtrx(self.sid, self._complex_byref(m), q)
 
     # multi-controlled single-qubit gates
 
@@ -136,7 +140,7 @@ class QrackSimulator:
         Qrack.qrack_lib.MCU(self.sid, len(c), self._uint_byref(c), q, th, ph, la)
 
     def mcmtrx(self, c, m, q):
-        Qrack.qrack_lib.MCMtrx(self.sid, len(c), self._uint_byref(c), self._double_byref(m), q)
+        Qrack.qrack_lib.MCMtrx(self.sid, len(c), self._uint_byref(c), self._complex_byref(m), q)
 
     # multi-anti-controlled single-qubit gates
 
@@ -168,7 +172,7 @@ class QrackSimulator:
         Qrack.qrack_lib.MACU(self.sid, len(c), self._uint_byref(c), q, c_double(th), c_double(ph), c_double(la))
 
     def macmtrx(self, c, m, q):
-        Qrack.qrack_lib.MACMtrx(self.sid, len(c), self._uint_byref(c), self._double_byref(m), q)
+        Qrack.qrack_lib.MACMtrx(self.sid, len(c), self._uint_byref(c), self._complex_byref(m), q)
 
     # rotations
 

--- a/pyqrack/qrack_simulator.py
+++ b/pyqrack/qrack_simulator.py
@@ -36,8 +36,8 @@ class QrackSimulator:
         return self._double_byref([item for sublist in t for item in sublist])
 
     def _to_ubyte(self, nv, v):
-        b = (c_ubyte * (1 << nv))()
         c = math.floor((nv - 1) / 8) + 1
+        b = (c_ubyte * (c * (1 << nv)))()
         n = 0
         for u in v:
             for i in range(c):

--- a/pyqrack/qrack_simulator.py
+++ b/pyqrack/qrack_simulator.py
@@ -41,7 +41,7 @@ class QrackSimulator:
             for u in v:
                 for i in range(c):
                     b.append(u & 0xFF)
-                    u >> 8
+                    u >>= 8
         else:
             b = v
 

--- a/pyqrack/qrack_simulator.py
+++ b/pyqrack/qrack_simulator.py
@@ -45,7 +45,7 @@ class QrackSimulator:
         else:
             b = v
 
-        return _ubyte_byref(self, b)
+        return self._ubyte_byref(b)
 
     def seed(self, s):
         Qrack.qrack_lib.seed(self.sid, s)
@@ -324,13 +324,13 @@ class QrackSimulator:
         Qrack.qrack_lib.MCPOWN(self.sid, a, len(c), c, m, len(q), self._uint_byref(q), self._uint_byref(o))
 
     def lda(self, qi, qv, t):
-        Qrack.qrack_lib.LDA(self.sid, len(qi), self._uint_byref(qi), len(qv), self._uint_byref(qv), self._to_ubyte(t))
+        Qrack.qrack_lib.LDA(self.sid, len(qi), self._uint_byref(qi), len(qv), self._uint_byref(qv), self._to_ubyte(len(qv), t))
 
     def adc(self, s, qi, qv, t):
-        Qrack.qrack_lib.ADC(self.sid, s, len(qi), self._uint_byref(qi), len(qv), self._uint_byref(qv), self._to_ubyte(t))
+        Qrack.qrack_lib.ADC(self.sid, s, len(qi), self._uint_byref(qi), len(qv), self._uint_byref(qv), self._to_ubyte(len(qv), t))
 
     def sbc(self, s, qi, qv, t):
-        Qrack.qrack_lib.SBC(self.sid, s, len(qi), self._uint_byref(qi), len(qv), self._uint_byref(qv), self._to_ubyte(t))
+        Qrack.qrack_lib.SBC(self.sid, s, len(qi), self._uint_byref(qi), len(qv), self._uint_byref(qv), self._to_ubyte(len(qv), t))
 
     # miscellaneous
 

--- a/pyqrack/qrack_simulator.py
+++ b/pyqrack/qrack_simulator.py
@@ -306,22 +306,22 @@ class QrackSimulator:
         Qrack.qrack_lib.MCADD(self.sid, a, len(c), c, len(q), self._uint_byref(q))
 
     def mcsub(self, a, c, q):
-        Qrack.qrack_lib.SUB(self.sid, a, len(c), c, len(q), self._uint_byref(q))
+        Qrack.qrack_lib.MCSUB(self.sid, a, len(c), c, len(q), self._uint_byref(q))
 
     def mcmul(self, a, c, q, o):
-        Qrack.qrack_lib.MUL(self.sid, a, len(c), c, len(q), self._uint_byref(q), self._uint_byref(o))
+        Qrack.qrack_lib.MCMUL(self.sid, a, len(c), c, len(q), self._uint_byref(q), self._uint_byref(o))
 
     def mcdiv(self, a, c, q, o):
-        Qrack.qrack_lib.DIV(self.sid, a, len(c), c, len(q), self._uint_byref(q), self._uint_byref(o))
+        Qrack.qrack_lib.MCDIV(self.sid, a, len(c), c, len(q), self._uint_byref(q), self._uint_byref(o))
 
     def mcmuln(self, a, c, m, q, o):
-        Qrack.qrack_lib.MULN(self.sid, a, len(c), c, m, len(q), self._uint_byref(q), self._uint_byref(o))
+        Qrack.qrack_lib.MCMULN(self.sid, a, len(c), c, m, len(q), self._uint_byref(q), self._uint_byref(o))
 
     def mcdivn(self, a, c, m, q, o):
-        Qrack.qrack_lib.DIVN(self.sid, a, len(c), c, m, len(q), self._uint_byref(q), self._uint_byref(o))
+        Qrack.qrack_lib.MCDIVN(self.sid, a, len(c), c, m, len(q), self._uint_byref(q), self._uint_byref(o))
 
-    def pown(self, a, c, m, q, o):
-        Qrack.qrack_lib.POWN(self.sid, a, len(c), c, m, len(q), self._uint_byref(q), self._uint_byref(o))
+    def mcpown(self, a, c, m, q, o):
+        Qrack.qrack_lib.MCPOWN(self.sid, a, len(c), c, m, len(q), self._uint_byref(q), self._uint_byref(o))
 
     def lda(self, qi, qv, t):
         Qrack.qrack_lib.LDA(self.sid, len(qi), self._uint_byref(qi), len(qv), self._uint_byref(qv), self._to_ubyte(t))
@@ -330,7 +330,7 @@ class QrackSimulator:
         Qrack.qrack_lib.ADC(self.sid, s, len(qi), self._uint_byref(qi), len(qv), self._uint_byref(qv), self._to_ubyte(t))
 
     def sbc(self, s, qi, qv, t):
-        Qrack.qrack_lib.ADC(self.sid, s, len(qi), self._uint_byref(qi), len(qv), self._uint_byref(qv), self._to_ubyte(t))
+        Qrack.qrack_lib.SBC(self.sid, s, len(qi), self._uint_byref(qi), len(qv), self._uint_byref(qv), self._to_ubyte(t))
 
     # miscellaneous
 

--- a/pyqrack/qrack_simulator.py
+++ b/pyqrack/qrack_simulator.py
@@ -31,21 +31,15 @@ class QrackSimulator:
     def _double_byref(self, a):
         return (c_double * len(a))(*a)
 
-    def _ubyte_byref(self, a):
-        return (c_ubyte * len(a))(*a)
-
     def _to_ubyte(self, nv, v):
-        b = []
+        b = (c_ubyte * (1 << nv))()
         c = math.floor((nv - 1) / 8) + 1
-        if c > 0:
-            for u in v:
-                for i in range(c):
-                    b.append(u & 0xFF)
-                    u >>= 8
-        else:
-            b = v
+        for u in v:
+            for i in range(c):
+                b[i] = u & 0xFF
+                u >>= 8
 
-        return self._ubyte_byref(b)
+        return byref(b)
 
     def seed(self, s):
         Qrack.qrack_lib.seed(self.sid, s)

--- a/pyqrack/qrack_simulator.py
+++ b/pyqrack/qrack_simulator.py
@@ -3,6 +3,7 @@
 # Use of this source code is governed by an MIT-style license that can be
 # found in the LICENSE file or at https://opensource.org/licenses/MIT.
 
+import math
 from ctypes import *
 from .qrack_system import Qrack
 
@@ -29,6 +30,22 @@ class QrackSimulator:
 
     def _double_byref(self, a):
         return (c_double * len(a))(*a)
+
+    def _ubyte_byref(self, a):
+        return (c_ubyte * len(a))(*a)
+
+    def _to_ubyte(self, nv, v):
+        b = []
+        c = math.floor(nv - 1) / 8) + 1
+        if c > 0:
+            for u in v:
+                for i in range(c):
+                    b.append(u & 0xFF)
+                    u >> 8
+        else:
+            b = v
+
+        return _ubyte_byref(self, b)
 
     def seed(self, s):
         Qrack.qrack_lib.seed(self.sid, s)
@@ -255,6 +272,72 @@ class QrackSimulator:
 
     def iqft(self, qs):
         Qrack.qrack_lib.IQFT(self.sid, len(qs), self._uint_byref(qs))
+
+    # Arithmetic-Logic-Unit (ALU)
+
+    def add(self, a, q):
+        Qrack.qrack_lib.ADD(self.sid, a, len(q), self._uint_byref(q))
+
+    def sub(self, a, q):
+        Qrack.qrack_lib.SUB(self.sid, a, len(q), self._uint_byref(q))
+
+    def adds(self, a, s, q):
+        Qrack.qrack_lib.ADDS(self.sid, a, s, len(q), self._uint_byref(q))
+
+    def subs(self, a, s, q):
+        Qrack.qrack_lib.SUBS(self.sid, a, s, len(q), self._uint_byref(q))
+
+    def mul(self, a, q, o):
+        Qrack.qrack_lib.MUL(self.sid, a, len(q), self._uint_byref(q), self._uint_byref(o))
+
+    def div(self, a, q, o):
+        Qrack.qrack_lib.DIV(self.sid, a, len(q), self._uint_byref(q), self._uint_byref(o))
+
+    def muln(self, a, m, q, o):
+        Qrack.qrack_lib.MULN(self.sid, a, m, len(q), self._uint_byref(q), self._uint_byref(o))
+
+    def divn(self, a, m, q, o):
+        Qrack.qrack_lib.DIVN(self.sid, a, m, len(q), self._uint_byref(q), self._uint_byref(o))
+
+    def pown(self, a, m, q, o):
+        Qrack.qrack_lib.POWN(self.sid, a, m, len(q), self._uint_byref(q), self._uint_byref(o))
+
+    def mcadd(self, a, c, q):
+        Qrack.qrack_lib.MCADD(self.sid, a, len(c), c, len(q), self._uint_byref(q))
+
+    def mcsub(self, a, c, q):
+        Qrack.qrack_lib.SUB(self.sid, a, len(c), c, len(q), self._uint_byref(q))
+
+    def mcmul(self, a, c, q, o):
+        Qrack.qrack_lib.MUL(self.sid, a, len(c), c, len(q), self._uint_byref(q), self._uint_byref(o))
+
+    def mcdiv(self, a, c, q, o):
+        Qrack.qrack_lib.DIV(self.sid, a, len(c), c, len(q), self._uint_byref(q), self._uint_byref(o))
+
+    def mcmuln(self, a, c, m, q, o):
+        Qrack.qrack_lib.MULN(self.sid, a, len(c), c, m, len(q), self._uint_byref(q), self._uint_byref(o))
+
+    def mcdivn(self, a, c, m, q, o):
+        Qrack.qrack_lib.DIVN(self.sid, a, len(c), c, m, len(q), self._uint_byref(q), self._uint_byref(o))
+
+    def pown(self, a, c, m, q, o):
+        Qrack.qrack_lib.POWN(self.sid, a, len(c), c, m, len(q), self._uint_byref(q), self._uint_byref(o))
+
+    def lda(self, qi, qv, t):
+        Qrack.qrack_lib.LDA(self.sid, len(qi), self._uint_byref(qi), len(qv), self._uint_byref(qv), self._to_ubyte(t))
+
+    def adc(self, s, qi, qv, t):
+        Qrack.qrack_lib.ADC(self.sid, s, len(qi), self._uint_byref(qi), len(qv), self._uint_byref(qv), self._to_ubyte(t))
+
+    def sbc(self, s, qi, qv, t):
+        Qrack.qrack_lib.ADC(self.sid, s, len(qi), self._uint_byref(qi), len(qv), self._uint_byref(qv), self._to_ubyte(t))
+
+MICROSOFT_QUANTUM_DECL void LDA(_In_ unsigned sid, _In_ unsigned ni, _In_reads_(ni) unsigned* qi, _In_ unsigned nv,
+    _In_reads_(nv) unsigned* qv, unsigned char* t);
+MICROSOFT_QUANTUM_DECL void ADC(_In_ unsigned sid, unsigned s, _In_ unsigned ni, _In_reads_(ni) unsigned* qi,
+    _In_ unsigned nv, _In_reads_(nv) unsigned* qv, unsigned char* t);
+MICROSOFT_QUANTUM_DECL void SBC(_In_ unsigned sid, unsigned s, _In_ unsigned ni, _In_reads_(ni) unsigned* qi,
+    _In_ unsigned nv, _In_reads_(nv) unsigned* qv, unsigned char* t);
 
     # miscellaneous
 

--- a/pyqrack/qrack_system/qrack_system.py
+++ b/pyqrack/qrack_system/qrack_system.py
@@ -275,6 +275,71 @@ class QrackSystem:
         self.qrack_lib.IQFT.resType = None
         self.qrack_lib.IQFT.argTypes = [c_uint, c_uint, POINTER(c_uint)]
 
+        # Arithmetic-Logic-Unit (ALU)
+
+        self.qrack_lib.ADD.resType = None
+        self.qrack_lib.ADD.argTypes = [c_uint, c_uint, c_uint, POINTER(c_uint)]
+
+        self.qrack_lib.SUB.resType = None
+        self.qrack_lib.SUB.argTypes = [c_uint, c_uint, c_uint, POINTER(c_uint)]
+
+        self.qrack_lib.ADDS.resType = None
+        self.qrack_lib.ADDS.argTypes = [c_uint, c_uint, c_uint, c_uint, POINTER(c_uint)]
+
+        self.qrack_lib.SUBS.resType = None
+        self.qrack_lib.SUBS.argTypes = [c_uint, c_uint, c_uint, c_uint, POINTER(c_uint)]
+
+        self.qrack_lib.MUL.resType = None
+        self.qrack_lib.MUL.argTypes = [c_uint, c_uint, c_uint, POINTER(c_uint), POINTER(c_uint)]
+
+        self.qrack_lib.DIV.resType = None
+        self.qrack_lib.DIV.argTypes = [c_uint, c_uint, c_uint, POINTER(c_uint), POINTER(c_uint)]
+
+        self.qrack_lib.MULN.resType = None
+        self.qrack_lib.MULN.argTypes = [c_uint, c_uint, c_uint, c_uint, POINTER(c_uint), POINTER(c_uint)]
+
+        self.qrack_lib.DIVN.resType = None
+        self.qrack_lib.DIVN.argTypes = [c_uint, c_uint, c_uint, c_uint, POINTER(c_uint), POINTER(c_uint)]
+
+        self.qrack_lib.POWN.resType = None
+        self.qrack_lib.POWN.argTypes = [c_uint, c_uint, c_uint, c_uint, POINTER(c_uint), POINTER(c_uint)]
+
+        self.qrack_lib.MCADD.resType = None
+        self.qrack_lib.MCADD.argTypes = [c_uint, c_uint, c_uint, POINTER(c_uint), c_uint, POINTER(c_uint)]
+
+        self.qrack_lib.MCSUB.resType = None
+        self.qrack_lib.MCSUB.argTypes = [c_uint, c_uint, c_uint, POINTER(c_uint), c_uint, POINTER(c_uint)]
+
+        self.qrack_lib.MCADDS.resType = None
+        self.qrack_lib.MCADDS.argTypes = [c_uint, c_uint, c_uint, POINTER(c_uint), c_uint, c_uint, POINTER(c_uint)]
+
+        self.qrack_lib.MCSUBS.resType = None
+        self.qrack_lib.MCSUBS.argTypes = [c_uint, c_uint, c_uint, POINTER(c_uint), c_uint, c_uint, POINTER(c_uint)]
+
+        self.qrack_lib.MCMUL.resType = None
+        self.qrack_lib.MCMUL.argTypes = [c_uint, c_uint, c_uint, POINTER(c_uint), c_uint, POINTER(c_uint), POINTER(c_uint)]
+
+        self.qrack_lib.MCDIV.resType = None
+        self.qrack_lib.MCDIV.argTypes = [c_uint, c_uint, c_uint, POINTER(c_uint), c_uint, POINTER(c_uint), POINTER(c_uint)]
+
+        self.qrack_lib.MCMULN.resType = None
+        self.qrack_lib.MCMULN.argTypes = [c_uint, c_uint, c_uint, POINTER(c_uint), c_uint, c_uint, POINTER(c_uint), POINTER(c_uint)]
+
+        self.qrack_lib.MCDIVN.resType = None
+        self.qrack_lib.MCDIVN.argTypes = [c_uint, c_uint, c_uint, POINTER(c_uint), c_uint, c_uint, POINTER(c_uint), POINTER(c_uint)]
+
+        self.qrack_lib.MCPOWN.resType = None
+        self.qrack_lib.MCPOWN.argTypes = [c_uint, c_uint, c_uint, POINTER(c_uint), c_uint, c_uint, POINTER(c_uint), POINTER(c_uint)]
+
+        self.qrack_lib.LDA.resType = None
+        self.qrack_lib.LDA.argType = [c_uint, c_uint, POINTER(c_uint), c_uint, POINTER(c_uint), POINTER(c_ubyte)]
+
+        self.qrack_lib.ADC.resType = None
+        self.qrack_lib.ADC.argType = [c_uint, c_uint, c_uint, POINTER(c_uint), c_uint, POINTER(c_uint), POINTER(c_ubyte)]
+
+        self.qrack_lib.SBC.resType = None
+        self.qrack_lib.SBC.argType = [c_uint, c_uint, c_uint, POINTER(c_uint), c_uint, POINTER(c_uint), POINTER(c_ubyte)]
+
         # miscellaneous
 
         self.qrack_lib.TrySeparate1Qb.resType = c_bool

--- a/pyqrack/qrack_system/qrack_system.py
+++ b/pyqrack/qrack_system/qrack_system.py
@@ -310,12 +310,6 @@ class QrackSystem:
         self.qrack_lib.MCSUB.resType = None
         self.qrack_lib.MCSUB.argTypes = [c_uint, c_uint, c_uint, POINTER(c_uint), c_uint, POINTER(c_uint)]
 
-        self.qrack_lib.MCADDS.resType = None
-        self.qrack_lib.MCADDS.argTypes = [c_uint, c_uint, c_uint, POINTER(c_uint), c_uint, c_uint, POINTER(c_uint)]
-
-        self.qrack_lib.MCSUBS.resType = None
-        self.qrack_lib.MCSUBS.argTypes = [c_uint, c_uint, c_uint, POINTER(c_uint), c_uint, c_uint, POINTER(c_uint)]
-
         self.qrack_lib.MCMUL.resType = None
         self.qrack_lib.MCMUL.argTypes = [c_uint, c_uint, c_uint, POINTER(c_uint), c_uint, POINTER(c_uint), POINTER(c_uint)]
 


### PR DESCRIPTION
This adds support for Qrack arithmetic (ALU) to `pyqrack`.

A quick way to test this, to some degree of user acceptance, is by _successfully_ implementing Grover's and Shor's, in the [vm6502q/pyqrack-jupyter](https://github.com/vm6502q/pyqrack-jupyter) repository. Neither this PR, nor the corresponding PR in vm6502q/qrack, will be merged before writing and successfully executing those examples.